### PR TITLE
Add breadscrumbs

### DIFF
--- a/app/assets/stylesheets/modules/_bread-crumbs.scss
+++ b/app/assets/stylesheets/modules/_bread-crumbs.scss
@@ -1,11 +1,23 @@
-.bread-crumbs {
-  height: 49px;
-  width: 100%;
+.bread {
+  font-size: 14px;
   border-top: 1px solid #eee;
   background: #FFF;
-  ul {
-    width: 1020px;
-    padding: 16px 0;
+  box-shadow: 0 3px 3px 0 rgba(0,0,0,0.16);
+  .breadcrumbs {
+    padding: 17px 0 17px;
     margin: 0 auto;
+    width: 1020px;
+    a {
+      display: inline-block;
+    }
+    a:hover {
+      color: #a9a9a9;
+      opacity: 50%;
+      text-decoration: underline;
+    }
+    span {
+      display: inline-block;
+      font-weight: bold;
+    }
   }
 }

--- a/app/views/credits/new.html.haml
+++ b/app/views/credits/new.html.haml
@@ -1,3 +1,4 @@
+- breadcrumb :credit
 .credit-content
   %section.credit-content__during.clearfix
     .credit-form

--- a/app/views/items/show.html.haml
+++ b/app/views/items/show.html.haml
@@ -1,3 +1,4 @@
+- breadcrumb :item_show
 .show-item
   / 商品の詳細
   .show-item__main

--- a/app/views/layouts/application.haml
+++ b/app/views/layouts/application.haml
@@ -11,8 +11,9 @@
   %body.main-container
     .main-container__box
       = render partial: "layouts/header"
-      .bread-crumbs
-        = render partial: "items/menulist"
+      .bread
+        = breadcrumbs separator: " &rsaquo; "
+
       = yield
       = render partial: "layouts/app-banner"
       = render partial: "layouts/footer"

--- a/app/views/layouts/application.haml
+++ b/app/views/layouts/application.haml
@@ -13,7 +13,6 @@
       = render partial: "layouts/header"
       .bread
         = breadcrumbs separator: " &rsaquo; "
-
       = yield
       = render partial: "layouts/app-banner"
       = render partial: "layouts/footer"

--- a/app/views/users/index.haml
+++ b/app/views/users/index.haml
@@ -1,3 +1,4 @@
+- breadcrumb :users
 .container
   .container__during
     %section.container__during--user-box
@@ -45,4 +46,3 @@
         %ul.user-item-list
           %li.user-item-not-found 取引中の商品がありません
   = render partial: 'user_side_bar'
-    

--- a/app/views/users/show.haml
+++ b/app/views/users/show.haml
@@ -1,3 +1,4 @@
+- breadcrumb :identification
 .user-identity
   .user-identity__area.clearfix
     .user-identity__area--profile

--- a/config/breadcrumbs.rb
+++ b/config/breadcrumbs.rb
@@ -1,0 +1,168 @@
+# 第1階層
+crumb :root do
+  link "メルカリ", root_path
+end
+
+crumb :support do
+  link "メルカリガイド", path
+end
+
+# 第2階層
+crumb :users do
+  link "マイページ", users_path
+  parent :root
+end
+
+crumb :categorys do
+  link "カテゴリー一覧", categorys_path
+  parent :root
+end
+
+crumb :brands do
+  link "ブランド一覧", brands_path
+  parent :root
+end
+
+crumb :regions do
+  link "出品地域一覧", path
+  parent :root
+end
+
+# 第3階層
+# カテゴリー一覧 > カテゴリー１
+crumb :category do |category|
+  link category.name, category_path
+  parent :categorys
+end
+
+# ブランド一覧 > ブランド
+crumb :brand do |brand|
+  link brand.name, brand_path
+  parent :brands
+end
+
+# リンク名(仮置き)
+crumb :item_show do
+  link "トップス", item_path
+  parent :root
+end
+
+crumb :notification do
+  link "お知らせ", path
+  parent :users
+end
+
+crumb :todo do
+  link "やることリスト", path
+  parent :users
+end
+
+crumb :likes do
+  link "いいね！一覧", path
+  parent :users
+end
+
+crumb :listing do
+  link "出品した商品・出品中", path
+  parent :users
+end
+
+crumb :in_progress do
+  link "出品した商品・取引中", path
+  parent :users
+end
+
+crumb :completed do
+  link "出品した商品・売却済み", path
+  parent :users
+end
+
+crumb :purchase do
+  link "購入した商品・取引中", path
+  parent :users
+end
+
+crumb :purchased do
+  link "購入した商品・過去の取引", path
+  parent :users
+end
+
+crumb :news do
+  link "ニュース一覧", path
+  parent :users
+end
+
+crumb :score do
+  link "評価一覧", path
+  parent :users
+end
+
+crumb :help_center do
+  link "お問い合わせ", path
+  parent :users
+end
+
+crumb :sales do
+  link "売上・振込申請", path
+  parent :users
+end
+
+crumb :point do
+  link "ポイント", path
+  parent :users
+end
+
+crumb :profile do
+  link "プロフィール", path
+  parent :users
+end
+
+crumb :deliver_addres do
+  link "住所変更", path
+  parent :users
+end
+
+crumb :credit do
+  link "支払い方法", new_credit_path
+  parent :users
+end
+
+crumb :email_password do
+  link "メール/パスワード", path
+  parent :users
+end
+
+crumb :identification do
+  link "本人情報の登録", user_path
+  parent :users
+end
+
+crumb :sms_confirmation do
+  link "電話番号の確認", path
+  parent :users
+end
+
+crumb :logout do
+  link "ログアウト", path
+  parent :users
+end
+
+# 第4階層
+# カテゴリー一覧 > カテゴリー１ > カテゴリー２
+crumb :category_second do |category|
+  link category.name, category_path
+  parent :category
+end
+
+# ブランド一覧 > ブランド > カテゴリー
+crumb :brand do |brand|
+  link category.name, brand_path
+  parent :brands
+end
+
+# 第5階層
+# カテゴリー一覧 > カテゴリー１ > カテゴリー２ > カテゴリー３
+crumb :category_third do |category|
+  link category.name, category_path
+  parent :category_third
+end


### PR DESCRIPTION
# WHAT
パンくずリストの実装

## _bread-crumbs.scss
パンくずリストを実装するにあたって変更しています

## 各 hamlファイル
パンくずリストが存在するページにコードを追加しています

## breadcrumbs.rb
パンくずリストで表示する、現在の階層名・パス指定・親のcrumbを定義しています。
現時点で実装済みの箇所はパス指定まで、実装されていない箇所は仮置きの状態です。
なのでカテゴリーやブランド名、商品名などはすべて仮置きです。
なお実装後に改めて追加していく形でやる予定をしております。
深い階層においては、コメントアウトで明記してあります。

#WHY
ユーザーが現在どの階層にいるかをわかりやすくするため。
そうすることで、ユーザビリティが向上したり、サイトの全体像がつかみやすくなるメリットがあるため
