### PR TITLE
Create brand page

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -16,6 +16,7 @@
 @import "modules/footer";
 @import "modules/progress-bar";
 
+@import "modules/brand-index";
 @import "modules/show-page";
 @import "modules/categories";
 @import "modules/user-items-box";

--- a/app/assets/stylesheets/modules/_brand-index.scss
+++ b/app/assets/stylesheets/modules/_brand-index.scss
@@ -1,0 +1,75 @@
+.brands__index {
+  &--box {
+    @include clearfix;
+    width: 1020px;
+    margin: 40px auto;
+    .title {
+      height: 72px;
+      width: 100%;
+      background-color: #ea352d;
+      border-top-left-radius: 4px;
+      border-top-right-radius: 4px;
+      h1 {
+        width: 80%;
+        color: #fff;
+        padding: 0 0 0 30px;
+        line-height: 72px;
+        font-size: 24px;
+        font-weight: bold;
+        float: left;
+      }
+      .brands__index--nav {
+        width: 10%;
+        .last {
+          display: block;
+          color: #fff;
+          line-height: 72px;
+          font-size: 20px;
+          text-align: center;
+          font-weight: bold;
+        }
+        .last:hover {
+          opacity: 0.8;
+          text-decoration: underline;
+        }
+      }
+    }
+    .brand {
+      @include clearfix;
+      background-color: #fff;
+      padding: 40px 60px;
+      &__container {
+        &--child {
+          width: 50%;
+          float: left;
+          a {
+            padding: 5px 10px 0 0;
+            display: block;
+            margin: 8px 0;
+            font-size: 16px;
+            color: #0099e8;
+          }
+          a:hover {
+            opacity: 0.8;
+            text-decoration: underline;
+          }
+        }
+      }
+    }
+    .top {
+      display: block;
+      float: right;
+      border: 1px solid #eee;
+      margin: 20px 0px;
+      padding: 20px 10px;
+      color: #0099e8;
+      background-color: #fff;
+      font-size: 16px;
+      font-weight: bold;
+    }
+    .top:hover {
+      opacity: 0.8;
+      text-decoration: underline;
+    }
+  }
+}

--- a/app/assets/stylesheets/modules/_pulldown-list.scss
+++ b/app/assets/stylesheets/modules/_pulldown-list.scss
@@ -2,6 +2,7 @@
   .category-nav {
     @include f-left;
     .pulldown-parent {
+      border: 1px solid #eee;
       width: auto;
       position: absolute;
       top: 90px;
@@ -25,9 +26,9 @@
           background-color: #ea352d;
         }
         .pulldown-child {
+          border: 1px solid #eee;
           display: none;
           position: absolute;
-          border-left: 1px solid #eee;
           top: 0;
           left: 224px;
           height: 572px;
@@ -49,6 +50,7 @@
               background-color: #eee;
             }
             .pulldown-descendant {
+              border: 1px solid #eee;
               display: none;
               position: absolute;
               border-left: 1px solid #eee;
@@ -70,6 +72,7 @@
     @include f-left;
     margin: 0 0 0 20px;
     .pulldown-brand {
+      border: 1px solid #eee;
       width: auto;
       position: absolute;
       top: 90px;

--- a/app/controllers/brands_controller.rb
+++ b/app/controllers/brands_controller.rb
@@ -1,6 +1,6 @@
 class BrandsController < ApplicationController
   def index
-    @brands = Brand.where(params[:id])
+    @brand_index = Brand.where(params[:id])
   end
 
   def show

--- a/app/models/brand.rb
+++ b/app/models/brand.rb
@@ -1,3 +1,3 @@
 class Brand < ApplicationRecord
-  has_many :messages
+  has_many :items
 end

--- a/app/views/brands/index.haml
+++ b/app/views/brands/index.haml
@@ -1,3 +1,15 @@
-- breadcrumb :brands, @brands
-- @brands.each do |brand|
-  = link_to brand.name, brand_path(brand)
+- breadcrumb :brands
+.brands__index
+  .brands__index--box
+    .title
+      %h1#top ブランド一覧
+      %span.brands__index--nav
+        = link_to "ページの最後へ", "#last", class: "last"
+    .brand
+      .brand__container
+        - @brand_index.each do |brand|
+          .brand__container--child
+            = link_to brand.name, brand_path(brand)
+    .last#last
+    = link_to "ページのトップへ", "#top", class: "top"
+

--- a/app/views/brands/show.haml
+++ b/app/views/brands/show.haml
@@ -1,1 +1,7 @@
 - breadcrumb :brand, @brand
+.show-page
+  .show-page__index
+    %h1
+      = @brand.name + "の商品一覧"
+    .show-page__index--content
+      = render partial: "items/content-item", collection: @brand.items.includes(:likes).order("id DESC"), as: "item"


### PR DESCRIPTION
# WHAT 
ブランド一覧ページの実装
ブランド毎の商品一覧ページの実装
Pulldownリストのscssを修正

## brands_controller.rb
Brandの変数名を変更

## brand.rb
アソシエーションが正しくなかったため修正

## index.haml
ブランド一覧ページのview

## show.haml
それぞれのブランドの商品一覧のview

# WHY
ユーザーがブランド一覧から選んでそれぞれのページに飛べるようにするため。
そうすることでユーザビリティの向上が見込める。
